### PR TITLE
fix react magnify right most zoom image on left side

### DIFF
--- a/src/components/PortfolioCard/PortfolioCard.jsx
+++ b/src/components/PortfolioCard/PortfolioCard.jsx
@@ -81,7 +81,15 @@ function PortfolioCard({
               }}
             />
           ) : (
-            <ReactImageMagnify {...{ ...getCardProps(imgSrc, idx) }} />
+            <ReactImageMagnify
+              {...{
+                ...getCardProps(imgSrc, idx),
+                enlargedImageContainerStyle: {
+                  left: "-105%",
+                  ...getCardProps(imgSrc, idx).enlargedImageContainerStyle,
+                },
+              }}
+            />
           )}
         </div>
       </div>

--- a/src/helper.js
+++ b/src/helper.js
@@ -75,7 +75,6 @@ export const arr = [
     position: "left",
     title: "Kyro Tools",
     techStack: ["ReactJS", "ElectronJS", "Docker", "Python", "NodeJS"],
-    // techStack: "ReactJS, ElectronJS, Docker, Python, NodeJS"
   },
   {
     imgSrc: [divine3, divine2, divine1, divine4, divine5, divine6],
@@ -84,7 +83,7 @@ export const arr = [
     classTitle: "divine",
     position: "right",
     title: "Divine",
-    techStack: ["ReactJS", "ElectronJS"],
+    techStack: ["ReactJS", "ElectronJS", "NodeJs", "Socket.io"],
   },
   {
     imgSrc: [hawa1, hawa2, hawa3, hawa4, hawa5, hawa6],
@@ -193,6 +192,6 @@ export const arr = [
     classTitle: "popbot",
     position: "right",
     title: "Popbot",
-    techStack: ["HTML", "CSS"],
+    techStack: ["HTML", "CSS", "ElectronJS"],
   },
 ];


### PR DESCRIPTION
Fixed  Magnifying right most images should go to the left #3 
- Made some changes in the portfolio card tech stack section for divine, popup bot 