### PR TITLE
pass tracking id to react ga initializer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ function App() {
     if (Boolean(isAccept)) {
       const trackingID = process.env.REACT_APP_TRACKING_ID;
       if (trackingID) {
-        ReactGA.initialize();
+        ReactGA.initialize(trackingID);
       }
     }
   }, [isAccept, userClick]);


### PR DESCRIPTION
- pass the google analytic tracking id to `ReactGA.initialize()` function in order to work 